### PR TITLE
remove temp file on ErrorException

### DIFF
--- a/Command/ApcClearCommand.php
+++ b/Command/ApcClearCommand.php
@@ -57,9 +57,14 @@ class ApcClearCommand extends ContainerAwareCommand
         $url = $this->getContainer()->getParameter('ornicar_apc.host').'/'.$filename;
 
         if ($this->getContainer()->getParameter('ornicar_apc.mode') == 'fopen') {
-            $result = file_get_contents($url);
+            try {
+                $result = file_get_contents($url);
 
-            if (!$result) {
+                if (!$result) {
+                    unlink($file);
+                    throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
+                }
+            } catch (\ErrorException $e) {
                 unlink($file);
                 throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
             }


### PR DESCRIPTION
If the file cannot be accessed via `file_get_contents` an `\Error_Exception` is thrown. The file should be unlinked in this case as well to have a clean state.
