### PR TITLE
Symfony 2.2 supprt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": ">=2.0,<2.2-dev"
+        "symfony/framework-bundle": ">=2.0,<2.3-dev"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Having upgraded to Symfony 2.2 I was unable to use this bundle as it kept wanting to downgrade to 2.1. Seems to be due to the limitation of Symfony version in the composer.json.
