### PR TITLE
added branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
     "require": {
         "symfony/framework-bundle": ">=2.0,<2.3-dev"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
     "autoload": {
         "psr-0": {
             "Ornicar\\ApcBundle": ""


### PR DESCRIPTION
Currently it's only possible to refer to this bundle via dev-master. This could cause trouble when changes are introduced later which break compatibility. With a branch-alias people can refer to 1.0.\* and BC-breaks can be introduced in a new version.
