### PR TITLE
changed symfony dependency to <3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": ">=2.0,<2.3-dev"
+        "symfony/framework-bundle": ">=2.0,<3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Change bundle to allow all versions of Symfony 2.x. This means that BC must be maintained in the future - but this should not be too much to ask for what is quite a simple bundle.
