### PR TITLE
Introduce testing using 'goutte' as optional clearing mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/Command/ApcClearCommand.php
+++ b/Command/ApcClearCommand.php
@@ -8,10 +8,96 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Loads initial data
+ * Class ApcClearCommand
+ * @package Ornicar\ApcBundle\Command
  */
 class ApcClearCommand extends ContainerAwareCommand
 {
+    /**
+     * @var boolean
+     */
+    public $clearMode;
+
+    /**
+     * @var boolean
+     */
+    public $clearOpCodeCacheOnly;
+
+    /**
+     * @var boolean
+     */
+    public $clearUserCacheOnly;
+
+    /**
+     * @var boolean
+     */
+    public $clearAll;
+
+    /**
+     * @var \Goutte\Client
+     */
+    public $client;
+
+    /**
+     * @var string
+     */
+    public $filePath;
+
+    /**
+     * @var string
+     */
+    public $host;
+
+    /**
+     * @var string
+     */
+    public $mode;
+
+    /**
+     * @var string
+     */
+    public $webDir;
+
+    /**
+     * @param string $mode
+     */
+    public function setMode($mode)
+    {
+        $this->mode = $mode;
+    }
+
+    /**
+     * @param mixed $clearMode
+     */
+    public function setClearMode($clearMode)
+    {
+        $this->clearMode = $clearMode;
+    }
+
+    /**
+     * @param mixed $host
+     */
+    public function setHost($host)
+    {
+        $this->host = $host;
+    }
+
+    /**
+     * @param \Goutte\Client $client
+     */
+    public function setClient($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param mixed $webDir
+     */
+    public function setWebDir($webDir)
+    {
+        $this->webDir = $webDir;
+    }
+
     /**
      * @see Command
      */
@@ -21,6 +107,12 @@ class ApcClearCommand extends ContainerAwareCommand
             ->setDefinition(array())
             ->addOption('opcode', null, InputOption::VALUE_NONE, 'Clear only opcode cache')
             ->addOption('user', null, InputOption::VALUE_NONE, 'Clear only user cache')
+            ->addOption('host', null, InputOption::VALUE_OPTIONAL,
+                'Server host from which a script clearing APC cache is triggered, e.g. --mode="http://127.0.0.1"')
+            ->addOption('mode', null, InputOption::VALUE_OPTIONAL,
+                'Clearing mode (possible choices are "fopen", "curl"), e.g. --mode=fopen)', 'fopen')
+            ->addOption('web_dir', null, InputOption::VALUE_OPTIONAL,
+                'Relative path to web dir (from kernel root dir, e.g. --web_dir="../web")')
             ->setName('apc:clear')
         ;
     }
@@ -30,75 +122,219 @@ class ApcClearCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $clearOpcode = $input->getOption('opcode') || !$input->getOption('user');
-        $clearUser = $input->getOption('user') || !$input->getOption('opcode');
+        $this->setUpOptions($input);
 
-        $webDir = $this->getContainer()->getParameter('ornicar_apc.web_dir');
-        if (!is_dir($webDir)) {
-            throw new \InvalidArgumentException(sprintf('Web dir does not exist "%s"', $webDir));
-        }
-        if (!is_writable($webDir)) {
-            throw new \InvalidArgumentException(sprintf('Web dir is not writable "%s"', $webDir));
-        }
         $filename = 'apc-'.md5(uniqid().mt_rand(0, 9999999).php_uname()).'.php';
-        $file = $webDir.'/'.$filename;
+        $this->filePath = $this->webDir.'/'.$filename;
 
-        $templateFile = __DIR__.'/../Resources/template.tpl';
-        $template = file_get_contents($templateFile);
-        $code = strtr($template, array(
-            '%user%' => var_export($clearUser, true),
-            '%opcode%' => var_export($clearOpcode, true)
-        ));
+        $this->saveClearCacheScript();
+        $url = $this->host . '/' . $filename;
 
-        if (false === @file_put_contents($file, $code)) {
-            throw new \RuntimeException(sprintf('Unable to write "%s"', $file));
-        }
-
-        if (!$host = $this->getContainer()->getParameter('ornicar_apc.host')) {
-            $host = sprintf("%s://%s", $this->getContainer()->getParameter('router.request_context.scheme'), $this->getContainer()->getParameter('router.request_context.host'));
-        }
-
-        $url = $host.'/'.$filename;
-
-        if ($this->getContainer()->getParameter('ornicar_apc.mode') == 'fopen') {
-            try {
-                $result = file_get_contents($url);
-
-                if (!$result) {
-                    unlink($file);
-                    throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
-                }
-            } catch (\ErrorException $e) {
-                unlink($file);
-                throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
-            }
-        }
-        else {
-            $ch = curl_init($url);
-            curl_setopt_array($ch, array(
-                CURLOPT_HEADER => false,
-                CURLOPT_RETURNTRANSFER => true,
-                CURLOPT_FAILONERROR => true
-            ));
-
-            $result = curl_exec($ch);
-
-            if (curl_errno($ch)) {
-                $error = curl_error($ch);
-                curl_close($ch);
-                unlink($file);
-                throw new \RuntimeException(sprintf('Curl error reading "%s": %s', $url, $error));
-            }
-            curl_close($ch);
+        if ($this->mode == 'fopen') {
+            $result = $this->clearCacheWithFopen($url);
+        } elseif ($this->mode == 'curl') {
+            $result = $this->clearCacheWithCurl($url);
+        } elseif ($this->mode == 'goutte') {
+            $result = $this->clearCacheWithGoutte($url);
         }
 
         $result = json_decode($result, true);
-        unlink($file);
+        $lastJsonError = json_last_error();
+        if ($lastJsonError !== JSON_ERROR_NONE) {
+            throw new \Exception(sprintf('Clearing APC cache failed with JSON decoding error code %d', $lastJsonError));
+        }
 
-        if($result['success']) {
+        unlink($this->filePath);
+
+        if ($result['success']) {
             $output->writeln($result['message']);
         } else {
             throw new \RuntimeException($result['message']);
+        }
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function setUpOptions(InputInterface $input)
+    {
+        $this->clearOpCodeCacheOnly = $input->getOption('opcode') || !$input->getOption('user');
+        $this->clearUserCacheOnly = $input->getOption('user') || !$input->getOption('opcode');
+
+        $this->setUpHost($input);
+        $this->setUpMode($input);
+        $this->setUpWebDir($input);
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function setUpHost(InputInterface $input)
+    {
+        if ($input->hasOption('host') && $input->getOption('host')) {
+            $this->host = $input->getOption('host');
+        } else {
+            if ($this->getContainer()->getParameter('ornicar_apc.host')) {
+                $this->host = $this->getContainer()->getParameter('ornicar_apc.host');
+            } else {
+                $this->host = sprintf("%s://%s", $this->getContainer()->getParameter('router.request_context.scheme'),
+                    $this->getContainer()->getParameter('router.request_context.host'));
+            }
+        }
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function setUpMode(InputInterface $input)
+    {
+        if ($input->hasOption('mode')) {
+            $this->mode = $input->getOption('mode');
+        } else {
+            $this->mode = $this->getContainer()->getParameter('ornicar_apc.mode');
+        }
+
+        $this->validateMode();
+    }
+
+
+    protected function validateMode()
+    {
+        $modes = array('fopen', 'curl', 'goutte');
+        if (is_null($this->mode) || !in_array($this->mode, $modes)) {
+            throw new \InvalidArgumentException('Clearing APC cache requires selecting one of the following modes: ' .
+            implode(', ', $modes));
+        }
+
+        if ($this->mode == 'curl' && !extension_loaded('curl')) {
+            throw new \InvalidArgumentException('Curl extension is missing.');
+        }
+
+        if ($this->mode == 'goutte' && !class_exists('\Goutte\Client')) {
+            throw new \InvalidArgumentException('Install Goutte Client by running "composer install --dev" from this project root directory.');
+        } else {
+            if (is_null($this->client)) {
+                $this->client = new \Goutte\Client;
+            }
+        }
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function setUpWebDir(InputInterface $input)
+    {
+        if (is_null($this->webDir)) {
+            if ($input->hasOption('web_dir') && $input->getOption('web_dir')) {
+                $kernelRootDir = $this->getContainer()->getParameter('kernel.root_dir');
+                $this->webDir = $kernelRootDir . '/' .  $input->getOption('web_dir');
+            } else {
+                $this->webDir = $this->getContainer()->getParameter('ornicar_apc.web_dir');
+            }
+        }
+
+        $this->validateWebDir();
+    }
+
+    protected function validateWebDir()
+    {
+        if (!is_dir($this->webDir)) {
+            throw new \InvalidArgumentException(sprintf('Web dir does not exist "%s"', $this->webDir));
+        }
+        if (!is_writable($this->webDir)) {
+            throw new \InvalidArgumentException(sprintf('Web dir is not writable "%s"', $this->webDir));
+        }
+    }
+
+    /**
+     * @param $url
+     * @return mixed
+     */
+    protected function clearCacheWithGoutte($url)
+    {
+        $this->client->request('GET', $url);
+
+        /**
+         * @var $response \Symfony\Component\BrowserKit\Response
+         */
+        $response = $this->client->getResponse();
+        if ($response->getStatus() !== 200) {
+            unlink($this->filePath);
+            throw new \Exception(sprintf('Has your host / server been properly configured? See also %s for nginx.',
+                'https://github.com/ornicar/ApcBundle/pull/22'));
+        }
+
+        return $response->getContent();
+    }
+
+    /**
+     * @param $url
+     * @throws \RuntimeException
+     */
+    protected function clearCacheWithCurl($url)
+    {
+        $ch = curl_init($url);
+        curl_setopt_array(
+            $ch,
+            array(
+                CURLOPT_HEADER => false,
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_FAILONERROR => true
+            )
+        );
+
+        $result = curl_exec($ch);
+
+        if (curl_errno($ch)) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            unlink($this->filePath);
+            throw new \RuntimeException(sprintf('Curl error reading "%s": %s', $url, $error));
+        }
+        curl_close($ch);
+
+        return $result;
+    }
+
+    /**
+     * @param $url
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function clearCacheWithFopen($url)
+    {
+        try {
+            $result = file_get_contents($url);
+
+            if (!$result) {
+                unlink($this->filePath);
+
+                throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
+            }
+        } catch (\ErrorException $e) {
+            unlink($this->filePath);
+            throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    protected function saveClearCacheScript()
+    {
+        $clearCacheTemplate = __DIR__ . '/../Resources/clear_cache.php.tpl';
+        $template = file_get_contents($clearCacheTemplate);
+        $code = strtr(
+            $template,
+            array(
+                '%clear_user_cache%' => var_export($this->clearUserCacheOnly, true),
+                '%clear_opcode_cache%' => var_export($this->clearOpCodeCacheOnly, true)
+            )
+        );
+        if (false === @file_put_contents($this->filePath, $code)) {
+            throw new \RuntimeException(sprintf('Unable to write "%s"', $this->filePath));
         }
     }
 }

--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,16 @@ Clear only user cache:
 
           $ php app/console apc:clear --user
 
+Testing
+=====
+
+Install development libraries:
+
+          $ composer update --dev --prefer-dist
+
+Run test suite from project root directory:
+
+          $ ./vendor/bin/phpunit -c phpunit.xml.dist
 
 Capifony usage
 ==============

--- a/Resources/clear_cache.php.tpl
+++ b/Resources/clear_cache.php.tpl
@@ -1,22 +1,21 @@
 <?php
+
 $message = 'Clear APC';
 $success = true;
 
-if(%user%) {
+if (%clear_user_cache%) {
     if (apc_clear_cache('user')) {
         $message .= ' User Cache: success';
-    }
-    else {
+    } else {
         $success = false;
         $message .= ' User Cache: failure';
     }
 }
 
-if(%opcode%) {
+if (%clear_opcode_cache%) {
     if (apc_clear_cache('opcode')) {
         $message .= ' Opcode Cache: success';
-    }
-    else {
+    } else {
         $success = false;
         $message .= ' Opcode Cache: failure';
     }

--- a/Tests/Command/ApcClearCommandTest.php
+++ b/Tests/Command/ApcClearCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Ornicar\ApcBundle\Tests\Command;
+
+use Symfony\Component\Console\Tester\CommandTester,
+    Symfony\Component\Console\Application;
+
+use Ornicar\ApcBundle\Command\ApcClearCommand;
+
+/**
+ * Class ApcClearCommandTest
+ * @author Thierry Marianne <thierry.marianne@weaving-the-web.org>
+ */
+class ApcClearCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExecute()
+    {
+        $application = new Application();
+        $clearCacheCommand = new ApcClearCommand();
+        $clearCacheCommand->setClearMode('goutte');
+
+        $clientMockBuilder = $this->getMockBuilder('\Goutte\Client');
+        $clientMock = $clientMockBuilder->disableOriginalConstructor()
+            ->setMethods(array('request', 'getResponse'))
+            ->getMock();
+
+        $responseMockBuilder = $this->getMockBuilder('\Symfony\Component\BrowserKit\Response');
+        $responseMock = $responseMockBuilder->disableOriginalConstructor()
+            ->setMethods(array('getContent', 'getStatus'))
+            ->getMock();
+
+        $successMessage = 'cache successfully cleared up';
+        $responseMock->expects($this->once())->method('getContent')->will($this->returnValue(json_encode(array(
+            'message' => $successMessage,  'success' => true))));
+        $responseMock->expects($this->once())->method('getStatus')->will($this->returnValue(200));
+
+        $clientMock->expects($this->once())->method('getResponse')->will($this->returnValue($responseMock));
+        $clearCacheCommand->setClient($clientMock);
+
+        $webDir = __DIR__;
+        $clearCacheCommand->setWebDir($webDir);
+
+        $application->add($clearCacheCommand);
+
+        $command = $application->find('apc:clear');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute(array('command' => $command->getName(),
+            '--mode' => 'goutte',
+            '--host' => 'http://127.0.0.1',
+            '--web_dir' => __DIR__));
+
+        $this->assertContains($successMessage, $commandTester->getDisplay());
+        $this->assertFileNotExists($command->filePath);
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
+    throw new \LogicException('Could not find autoload.php in vendor/. Did you run "composer install --dev"?');
+}
+
+require $autoloadFile;

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,14 @@
     "require": {
         "symfony/framework-bundle": ">=2.1,<3.0"
     },
+    "suggest": {
+        "fabpot/goutte": "To extract data from html/xml responses"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*",
+        "symfony/console": ">=2.0,<3.0",
+        "fabpot/goutte": "1.*"
+    },
     "extra": {
         "branch-alias": {
             "dev-1.0": "1.0.x-dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="./Tests/bootstrap.php" colors="true">
+
+    <testsuites>
+        <testsuite name="OrnicarApcBundle test suite">
+            <directory suffix="Test.php">./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
There is no more assumption about possible use of APCu.

For PHP 5.5 and above, I would suggest in a separate PR https://github.com/thierrymarianne/ApcBundle/commit/8404f711867537d61334d0ba0de7579fc0f228d9 :
- to check if APCu extension is loaded before trying to clear user cache  
- to throw an exception when simply trying to use the command for main opcode cache clearing
