### PR TITLE
added "--cli" option to apc:clear command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,10 @@ Clear only user cache:
 
           $ php app/console apc:clear --user
 
+Clear the CLI cache (opcode+user):
+
+          $ php app/console apc:clear --cli
+
 
 Capifony usage
 ==============


### PR DESCRIPTION
I have a variety of servers in production, some of which have a web presence, some of which do not.  I need to clear the APC cache on all of them, but the command currently only takes care of clearing the cache via the web.  I can't use the command to clear caches on the machines that are only doing cli work.

This just adds a `--cli` option to the current command, which will clear the cache via the CLI, instead of the web.
