### PR TITLE
APCu and OPcache support added

### DIFF
--- a/Resources/template.tpl
+++ b/Resources/template.tpl
@@ -7,7 +7,7 @@ if(%user%) {
         $message .= ' User Cache: success';
     }
     elseif (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '<') && apc_clear_cache('user')) {
-        $message .= ' Opcode Cache: success';
+        $message .= ' User Cache: success';
     }
     else {
         $success = false;


### PR DESCRIPTION
Apc is not available for PHP 5.5 as [OPcache](http://php.net/manual/en/book.opcache.php) is included by default. However there is an alternative for apc user cache: [APCu](https://github.com/krakjoe/apcu). Although APCu functions are backward compatible `apc_clear_cache` doesn't accept any parameters as it only handles the user cache.

Modified the script template for both APCu user cache and PHP 5.5 default OPcache support.
