### PR TITLE
do not enforce dev-master in composer.json

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ Installation
       ```json
       {
           "require": {
-              "ornicar/apc-bundle": "dev-master"
+              "ornicar/apc-bundle": "1.0.*"
           }
       }
       ```


### PR DESCRIPTION
By the way, how about a new tag? 1.0.0 is pretty old.
