### PR TITLE
[Bugfix] Hide warnings

### DIFF
--- a/Command/ApcClearCommand.php
+++ b/Command/ApcClearCommand.php
@@ -77,7 +77,7 @@ class ApcClearCommand extends ContainerAwareCommand
         if ($this->getContainer()->getParameter('ornicar_apc.mode') == 'fopen') {
             $result = false;
             for ($i = 0; $i<5; $i++){
-                if ($result = file_get_contents($url)){
+                if ($result = @file_get_contents($url)){
                     break;
                 } else {
                     sleep(1);


### PR DESCRIPTION
If the host does not locally resolve we don't want a lot of php warnings before I get the error message.
