### PR TITLE
Retry curl request 5 times if it fails

### DIFF
--- a/Command/ApcClearCommand.php
+++ b/Command/ApcClearCommand.php
@@ -97,8 +97,7 @@ class ApcClearCommand extends ContainerAwareCommand
                 unlink($file);
                 throw new \RuntimeException(sprintf('Unable to read "%s", does the host locally resolve?', $url));
             }
-        }
-        else {
+        } else {
             $ch = curl_init($url);
             curl_setopt_array($ch, array(
                 CURLOPT_HEADER => false,
@@ -110,18 +109,25 @@ class ApcClearCommand extends ContainerAwareCommand
                 curl_setopt($ch, CURLOPT_USERPWD, $auth);
             }
 
-            $result = curl_exec($ch);
-
-            if (curl_errno($ch)) {
-                $error = curl_error($ch);
-                curl_close($ch);
-                unlink($file);
-                throw new \RuntimeException(sprintf('Curl error reading "%s": %s', $url, $error));
+            for ($i = 0; $i<5; $i++){
+                $result = curl_exec($ch);
+                if (curl_errno($ch)) {
+                    $success = false;
+                    $error = curl_error($ch);
+                    $output->writeln(sprintf('Error attempting clear #%s with message %s', $i, $error));
+                    sleep(1);
+                    continue;
+                } else {
+                    $success = true;
+                    $result = json_decode($result, true);
+                    break;
+                }
             }
-            curl_close($ch);
         }
-
-        $result = json_decode($result, true);
+        curl_close($ch);
+        if (!$success) {
+            throw new \RuntimeException(sprintf('Curl error reading "%s": %s', $url, $error));
+        }
         unlink($file);
 
         if($result['success']) {

--- a/Command/ApcClearCommand.php
+++ b/Command/ApcClearCommand.php
@@ -109,13 +109,13 @@ class ApcClearCommand extends ContainerAwareCommand
                 curl_setopt($ch, CURLOPT_USERPWD, $auth);
             }
 
-            for ($i = 0; $i<5; $i++){
+            for ($i = 1; $i<6; $i++){
                 $result = curl_exec($ch);
                 if (curl_errno($ch)) {
                     $success = false;
                     $error = curl_error($ch);
                     $output->writeln(sprintf('Error attempting clear #%s with message %s', $i, $error));
-                    sleep(1);
+                    sleep($i);
                     continue;
                 } else {
                     $success = true;
@@ -131,7 +131,7 @@ class ApcClearCommand extends ContainerAwareCommand
         unlink($file);
 
         if($result['success']) {
-            $output->writeln('Web: '.$result['message'].". Reset attempts: ".(empty($i) ? 1 : $i+1).".");
+            $output->writeln('Web: '.$result['message'].". Reset attempts: ".(empty($i) ? 1 : $i).".");
         } else {
             throw new \RuntimeException($result['message']);
         }


### PR DESCRIPTION
If the curl request fails when clearing, retry 5 times, gradually increasing the time between retries (from 1 to 5 seconds).
