### PR TITLE
Changed configuration to implement ConfigurationInterface

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace Ornicar\ApcBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -10,18 +11,17 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  * This information is solely responsible for how the different configuration
  * sections are normalized, and merged.
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
     /**
-     * Generates the configuration tree.
-     *
-     * @return \Symfony\Component\DependencyInjection\Configuration\NodeInterface
+     * {@inheritDoc}
      */
-    public function getConfigTree()
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('ornicar_apc', 'array')
-            ->isRequired()
+        $rootNode = $treeBuilder->root('ornicar_apc');
+
+        $rootNode
             ->children()
                 ->scalarNode('host')->defaultFalse()->end()
                 ->scalarNode('web_dir')->isRequired()->end()
@@ -29,6 +29,6 @@ class Configuration
             ->end()
         ->end();
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 }


### PR DESCRIPTION
I've updated the Configuration class to the current Symfony (2.3+) standard as you can read from: http://symfony.com/doc/2.3/components/config/definition.html

Also, by implementing this interface the configuration become dumpable by the console command.
