### PR TITLE
Fix regression introduced by PR #36 (ConfigurationInterface)

### DIFF
--- a/DependencyInjection/OrnicarApcExtension.php
+++ b/DependencyInjection/OrnicarApcExtension.php
@@ -10,9 +10,8 @@ class OrnicarApcExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
-        $processor = new Processor();
         $configuration = new Configuration();
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
         if ($config['host'] && strncmp($config['host'], 'http', 4) !== 0) {
             $config['host'] = 'http://'.$config['host'];


### PR DESCRIPTION
Sorry to say, but I've introduced a bug with my previous PR #36 . It just showed up on a composer install of version 1.0.3.

I've replaced `getConfigTree` with `getConfigTreeBuilder`, but since my local test went ok (damned APC) I though it was just a deprecated method. It was not, it was called in `OrnicarApcExtension`. I've aligned also that class.

Sorry for the double release.
