### PR TITLE
Add Composer's auto-clean support

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Ornicar\ApcBundle\Composer;
+
+use Composer\Script\CommandEvent;
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as SymfonyScriptHandler;
+
+class ScriptHandler extends SymfonyScriptHandler
+{
+
+    /**
+     * Clears the APC/Opcache cache.
+     *
+     * @param $event CommandEvent A instance
+     */
+    public static function clearApcCache(CommandEvent $event)
+    {
+        $options = parent::getOptions($event);
+        $consoleDir = parent::getConsoleDir($event, 'clear the apc cache');
+
+        if (null === $consoleDir) {
+            return;
+        }
+
+        $opcode = '';
+        if (array_key_exists('ornicar-apc-opcode', $options))
+        {
+            $opcode .= ' --opcode';
+        }
+
+        $user = '';
+        if (array_key_exists('ornicar-apc-user', $options))
+        {
+            $user .= ' --user';
+        }
+
+        $cli = '';
+        if (array_key_exists('ornicar-apc-cli', $options))
+        {
+            $cli .= ' --cli';
+        }
+
+        $auth = '';
+        if (array_key_exists('ornicar-apc-auth', $options))
+        {
+            $auth .= ' --auth '.  escapeshellarg($options['ornicar-apc-auth']);
+        }
+
+        static::executeCommand($event, $consoleDir, 'apc:clear'.$opcode.$user.$cli.$auth, $options['process-timeout']);
+    }
+
+}

--- a/README.markdown
+++ b/README.markdown
@@ -91,11 +91,11 @@ To automatically clear apc cache after each composer install / composer update, 
         "post-install-cmd": [
           ...
           "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
-        }
+        ],
         "post-update-cmd": [
           ...
           "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
-        }
+        ]
 ```
 
 You can specify command arguments in the `extra` section:
@@ -104,7 +104,7 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-          ...
+
           "ornicar-apc-opcode": "yes"
         }
 ```
@@ -113,7 +113,7 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-          ...
+
           "ornicar-apc-user": "yes"
         }
 ```
@@ -122,7 +122,7 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-          ...
+        
           "ornicar-apc-cli": "yes"
         }
 ```
@@ -131,7 +131,7 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-          ...
+
           "ornicar-apc-auth": "username:password"
         }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -82,6 +82,61 @@ Clear the CLI cache (opcode+user):
           $ php app/console apc:clear --cli
 
 
+Composer usage
+==============
+
+To automatically clear apc cache after each composer install / composer update, you can add a script handler to your project's composer.json :
+
+```json
+        "post-install-cmd": [
+          ...
+          "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
+        }
+        "post-update-cmd": [
+          ...
+          "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
+        }
+```
+
+You can specify command arguments in the `extra` section:
+
+- `--opcode` (to clean only opcode cache): 
+
+```json
+        "extra": [
+          ...
+          "ornicar-apc-opcode": "yes"
+        }
+```
+
+- `--user` (to clean only user cache): 
+
+```json
+        "extra": [
+          ...
+          "ornicar-apc-user": "yes"
+        }
+```
+
+- `--cli` (to only clear cache via the CLI): 
+
+```json
+        "extra": [
+          ...
+          "ornicar-apc-cli": "yes"
+        }
+```
+
+- `--auth` (HTTP authentification): 
+
+```json
+        "extra": [
+          ...
+          "ornicar-apc-auth": "username:password"
+        }
+```
+
+
 Capifony usage
 ==============
 

--- a/README.markdown
+++ b/README.markdown
@@ -89,11 +89,11 @@ To automatically clear apc cache after each composer install / composer update, 
 
 ```json
         "post-install-cmd": [
-          ...
+          
           "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
         ],
         "post-update-cmd": [
-          ...
+          
           "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
         ]
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -89,11 +89,9 @@ To automatically clear apc cache after each composer install / composer update, 
 
 ```json
         "post-install-cmd": [
-          
           "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
         ],
         "post-update-cmd": [
-          
           "Ornicar\\ApcBundle\\Composer\\ScriptHandler::clearApcCache"
         ]
 ```
@@ -104,7 +102,6 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-
           "ornicar-apc-opcode": "yes"
         }
 ```
@@ -113,7 +110,6 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-
           "ornicar-apc-user": "yes"
         }
 ```
@@ -122,7 +118,6 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-        
           "ornicar-apc-cli": "yes"
         }
 ```
@@ -131,7 +126,6 @@ You can specify command arguments in the `extra` section:
 
 ```json
         "extra": {
-
           "ornicar-apc-auth": "username:password"
         }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -103,7 +103,7 @@ You can specify command arguments in the `extra` section:
 - `--opcode` (to clean only opcode cache): 
 
 ```json
-        "extra": [
+        "extra": {
           ...
           "ornicar-apc-opcode": "yes"
         }
@@ -112,7 +112,7 @@ You can specify command arguments in the `extra` section:
 - `--user` (to clean only user cache): 
 
 ```json
-        "extra": [
+        "extra": {
           ...
           "ornicar-apc-user": "yes"
         }
@@ -121,7 +121,7 @@ You can specify command arguments in the `extra` section:
 - `--cli` (to only clear cache via the CLI): 
 
 ```json
-        "extra": [
+        "extra": {
           ...
           "ornicar-apc-cli": "yes"
         }
@@ -130,7 +130,7 @@ You can specify command arguments in the `extra` section:
 - `--auth` (HTTP authentification): 
 
 ```json
-        "extra": [
+        "extra": {
           ...
           "ornicar-apc-auth": "username:password"
         }


### PR DESCRIPTION
Cleans cache on composer install / composer update.

```
ninsuo:project alain$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Writing lock file
Generating autoload files
Updating the "app/config/parameters.yml" file
Clearing the cache for the dev environment with debug true
Installing assets as symlinks
Installing assets for Symfony\Bundle\FrameworkBundle into web/bundles/framework
Installing assets for Fuz\AppBundle into web/bundles/fuzapp
Installing assets for Sensio\Bundle\DistributionBundle into web/bundles/sensiodistribution
Web: Clear APC User Cache: success Opcode Cache: success. Reset attempts: 1.
ninsuo:project alain$ 
```
