### PR TITLE
Using latest_release instead of current_path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,7 +92,7 @@ namespace :symfony do
   desc "Clear apc cache"
   task :clear_apc do
     capifony_pretty_print "--> Clear apc cache"
-    run "#{try_sudo} sh -c 'cd #{current_path} && #{php_bin} #{symfony_console} apc:clear --env=#{symfony_env_prod}'"
+    run "#{try_sudo} sh -c 'cd #{latest_release} && #{php_bin} #{symfony_console} apc:clear #{console_options}'"
     capifony_puts_ok
   end
 end


### PR DESCRIPTION
50% of all my deploys fails because I cant execute the script. I get a 404. Somehow `/current` may link to the old release... Anyhow: If you are using `latest_release` you will not have this issue.
