### PR TITLE
Allow custom CURL option in configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,6 +26,19 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('host')->defaultFalse()->end()
                 ->scalarNode('web_dir')->isRequired()->end()
                 ->scalarNode('mode')->defaultValue('fopen')->end()
+                ->arrayNode('curl_opts')
+                    ->validate()
+                        ->always(function ($opts) {
+                            foreach (array_keys($opts) as $const)
+                                if (! defined($const) || substr($const, 0, 8) !== 'CURLOPT_')
+                                    throw new \InvalidArgumentException(sprintf("%s is not a valid CURLOPT option. (http://php.net/manual/en/function.curl-setopt.php)", json_encode($const)));
+                            return $opts;
+                        })
+                    ->end()
+                    ->defaultValue(array())
+                    ->useAttributeAsKey('name', false)
+                    ->prototype('scalar')->end()
+                ->end()
             ->end()
         ->end();
 

--- a/DependencyInjection/OrnicarApcExtension.php
+++ b/DependencyInjection/OrnicarApcExtension.php
@@ -19,5 +19,11 @@ class OrnicarApcExtension extends Extension
         $container->setParameter('ornicar_apc.host', $config['host'] ? trim($config['host'], '/') : false);
         $container->setParameter('ornicar_apc.web_dir', $config['web_dir']);
         $container->setParameter('ornicar_apc.mode', $config['mode']);
+
+        $curlOpts = array();
+        foreach ($config['curl_opts'] as $name => $value) {
+            $curlOpts[constant($name)] = $value;
+        }
+        $container->setParameter('ornicar_apc.curl_opts', $curlOpts);
     }
 }

--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,9 @@ Installation
           ornicar_apc:
               ...
               mode: curl
+          #   additional options can be passed to the command
+          #   curl_opts:
+          #       CURLOPT_*: custom_value
 
 
 Usage


### PR DESCRIPTION
Disclaimer: I've just saw that you no longer maintain this bundle, but since I've already did this patch all send a PR anyway for reference (maybe someone will use it). Of course, it would be nice if you'll merge this anyway :)

I've added a configuration entry to pass custom curl options to the clear command.
My use case is for setting a custom certification authority, but there are countless other scenario, since there is no way to set global curl settings (AFAIK).
